### PR TITLE
Add support for Ed25519, change signing interface to support crypto.Signer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go: ['1.12', '1.13', '1.14', '1.15', '1.16']
+        go: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on: [push, pull_request]
 
+env: 
+  GODEBUG=x509sha1=1
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 
 env: 
-  GODEBUG=x509sha1=1
+  GODEBUG: x509sha1=1
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/digitorus/pkcs7
 
-go 1.11
+go 1.13

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -2,6 +2,7 @@ package pkcs7
 
 import (
 	"crypto"
+	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -134,6 +135,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA1
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA1
 		}
 	case x509.SHA256WithRSA:
 		priv = test2048Key
@@ -144,6 +147,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA256
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA256
 		}
 	case x509.SHA384WithRSA:
 		priv = test3072Key
@@ -154,6 +159,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA384
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA256
 		}
 	case x509.SHA512WithRSA:
 		priv = test4096Key
@@ -164,6 +171,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA512
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA256
 		}
 	case x509.ECDSAWithSHA1:
 		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -177,6 +186,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA1
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA1
 		}
 	case x509.ECDSAWithSHA256:
 		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -190,6 +201,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA256
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA256
 		}
 	case x509.ECDSAWithSHA384:
 		priv, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
@@ -203,6 +216,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA384
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA256
 		}
 	case x509.ECDSAWithSHA512:
 		priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
@@ -216,7 +231,31 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA512
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA256
 		}
+	case x509.DSAWithSHA1:
+		var dsaPriv dsa.PrivateKey
+		params := &dsaPriv.Parameters
+		err = dsa.GenerateParameters(params, rand.Reader, dsa.L1024N160)
+		if err != nil {
+			return nil, err
+		}
+		err = dsa.GenerateKey(&dsaPriv, rand.Reader)
+		if err != nil {
+			return nil, err
+		}
+		switch issuerKey.(type) {
+		case *rsa.PrivateKey:
+			template.SignatureAlgorithm = x509.SHA1WithRSA
+		case *ecdsa.PrivateKey:
+			template.SignatureAlgorithm = x509.ECDSAWithSHA1
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA1
+		}
+		priv = &dsaPriv
 	case x509.PureEd25519:
 		_, priv, err = ed25519.GenerateKey(rand.Reader)
 		if err != nil {
@@ -229,6 +268,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.ECDSAWithSHA256
 		case ed25519.PrivateKey:
 			template.SignatureAlgorithm = x509.PureEd25519
+		case *dsa.PrivateKey:
+			template.SignatureAlgorithm = x509.DSAWithSHA256
 		}
 	}
 	if isCA {
@@ -252,6 +293,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey)
 		case ed25519.PrivateKey:
 			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey)
+		case *dsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey)
 		}
 	case *ecdsa.PrivateKey:
 		switch issuerKey := issuerKey.(type) {
@@ -260,6 +303,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 		case *ecdsa.PrivateKey:
 			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey)
 		case ed25519.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey)
+		case *dsa.PrivateKey:
 			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey)
 		}
 	case ed25519.PrivateKey:
@@ -270,6 +315,20 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(ed25519.PrivateKey).Public(), issuerKey)
 		case ed25519.PrivateKey:
 			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(ed25519.PrivateKey).Public(), issuerKey)
+		case *dsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(ed25519.PrivateKey).Public(), issuerKey)
+		}
+	case *dsa.PrivateKey:
+		pub := &priv.(*dsa.PrivateKey).PublicKey
+		switch issuerKey := issuerKey.(type) {
+		case *rsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, pub, issuerKey)
+		case *ecdsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey)
+		case ed25519.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(dsa.PublicKey), issuerKey)
+		case *dsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey)
 		}
 	}
 	if err != nil {

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -2,8 +2,8 @@ package pkcs7
 
 import (
 	"crypto"
-	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -132,8 +132,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA1WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA1
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA1
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
 	case x509.SHA256WithRSA:
 		priv = test2048Key
@@ -142,8 +142,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA256WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA256
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA256
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
 	case x509.SHA384WithRSA:
 		priv = test3072Key
@@ -152,8 +152,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA384WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA384
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA256
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
 	case x509.SHA512WithRSA:
 		priv = test4096Key
@@ -162,8 +162,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA512WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA512
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA256
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
 	case x509.ECDSAWithSHA1:
 		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -175,8 +175,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA1WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA1
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA1
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
 	case x509.ECDSAWithSHA256:
 		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -188,8 +188,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA256WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA256
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA256
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
 	case x509.ECDSAWithSHA384:
 		priv, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
@@ -201,8 +201,8 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA384WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA384
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA256
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
 	case x509.ECDSAWithSHA512:
 		priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
@@ -214,29 +214,22 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 			template.SignatureAlgorithm = x509.SHA512WithRSA
 		case *ecdsa.PrivateKey:
 			template.SignatureAlgorithm = x509.ECDSAWithSHA512
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA256
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
-	case x509.DSAWithSHA1:
-		var dsaPriv dsa.PrivateKey
-		params := &dsaPriv.Parameters
-		err = dsa.GenerateParameters(params, rand.Reader, dsa.L1024N160)
-		if err != nil {
-			return nil, err
-		}
-		err = dsa.GenerateKey(&dsaPriv, rand.Reader)
+	case x509.PureEd25519:
+		_, priv, err = ed25519.GenerateKey(rand.Reader)
 		if err != nil {
 			return nil, err
 		}
 		switch issuerKey.(type) {
 		case *rsa.PrivateKey:
-			template.SignatureAlgorithm = x509.SHA1WithRSA
+			template.SignatureAlgorithm = x509.SHA256WithRSA
 		case *ecdsa.PrivateKey:
-			template.SignatureAlgorithm = x509.ECDSAWithSHA1
-		case *dsa.PrivateKey:
-			template.SignatureAlgorithm = x509.DSAWithSHA1
+			template.SignatureAlgorithm = x509.ECDSAWithSHA256
+		case ed25519.PrivateKey:
+			template.SignatureAlgorithm = x509.PureEd25519
 		}
-		priv = &dsaPriv
 	}
 	if isCA {
 		template.IsCA = true
@@ -252,32 +245,31 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 	log.Println("creating cert", name, "issued by", issuerCert.Subject.CommonName, "with sigalg", sigAlg)
 	switch priv.(type) {
 	case *rsa.PrivateKey:
-		switch issuerKey.(type) {
-		case *rsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey.(*rsa.PrivateKey))
-		case *ecdsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey.(*ecdsa.PrivateKey))
-		case *dsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey.(*dsa.PrivateKey))
-		}
-	case *ecdsa.PrivateKey:
-		switch issuerKey.(type) {
-		case *rsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey.(*rsa.PrivateKey))
-		case *ecdsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey.(*ecdsa.PrivateKey))
-		case *dsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey.(*dsa.PrivateKey))
-		}
-	case *dsa.PrivateKey:
-		pub := &priv.(*dsa.PrivateKey).PublicKey
 		switch issuerKey := issuerKey.(type) {
 		case *rsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, pub, issuerKey)
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey)
 		case *ecdsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey)
-		case *dsa.PrivateKey:
-			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*dsa.PublicKey), issuerKey)
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey)
+		case ed25519.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*rsa.PrivateKey).Public(), issuerKey)
+		}
+	case *ecdsa.PrivateKey:
+		switch issuerKey := issuerKey.(type) {
+		case *rsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey)
+		case *ecdsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey)
+		case ed25519.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(*ecdsa.PrivateKey).Public(), issuerKey)
+		}
+	case ed25519.PrivateKey:
+		switch issuerKey := issuerKey.(type) {
+		case *rsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(ed25519.PrivateKey).Public(), issuerKey)
+		case *ecdsa.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(ed25519.PrivateKey).Public(), issuerKey)
+		case ed25519.PrivateKey:
+			derCert, err = x509.CreateCertificate(rand.Reader, &template, issuerCert, priv.(ed25519.PrivateKey).Public(), issuerKey)
 		}
 	}
 	if err != nil {

--- a/sign_test.go
+++ b/sign_test.go
@@ -3,6 +3,7 @@ package pkcs7
 import (
 	"bytes"
 	"crypto"
+	"crypto/dsa"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/pem"
@@ -57,7 +58,7 @@ func TestSign(t *testing.T) {
 					signerDigest, _ := getDigestOIDForSignatureAlgorithm(signerCert.Certificate.SignatureAlgorithm)
 					toBeSigned.SetDigestAlgorithm(signerDigest)
 
-					if err := toBeSigned.AddSignerChain(signerCert.Certificate, (*signerCert.PrivateKey).(crypto.Signer), parents, SignerInfoConfig{}); err != nil {
+					if err := toBeSigned.AddSignerChain(signerCert.Certificate, *signerCert.PrivateKey, parents, SignerInfoConfig{}); err != nil {
 						t.Fatalf("test %s/%s/%s: cannot add signer: %s", sigalgroot, sigalginter, sigalgsigner, err)
 					}
 					if testDetach {
@@ -89,6 +90,72 @@ func TestSign(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDSASignAndVerifyWithOpenSSL(t *testing.T) {
+	content := []byte("Hello World")
+	// write the content to a temp file
+	tmpContentFile, err := ioutil.TempFile("", "TestDSASignAndVerifyWithOpenSSL_content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(tmpContentFile.Name(), content, 0755)
+
+	block, _ := pem.Decode([]byte(dsaPublicCert))
+	if block == nil {
+		t.Fatal("failed to parse certificate PEM")
+	}
+	signerCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal("failed to parse certificate: " + err.Error())
+	}
+
+	// write the signer cert to a temp file
+	tmpSignerCertFile, err := ioutil.TempFile("", "TestDSASignAndVerifyWithOpenSSL_signer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(tmpSignerCertFile.Name(), dsaPublicCert, 0755)
+
+	priv := dsa.PrivateKey{
+		PublicKey: dsa.PublicKey{Parameters: dsa.Parameters{P: fromHex("fd7f53811d75122952df4a9c2eece4e7f611b7523cef4400c31e3f80b6512669455d402251fb593d8d58fabfc5f5ba30f6cb9b556cd7813b801d346ff26660b76b9950a5a49f9fe8047b1022c24fbba9d7feb7c61bf83b57e7c6a8a6150f04fb83f6d3c51ec3023554135a169132f675f3ae2b61d72aeff22203199dd14801c7"),
+			Q: fromHex("9760508F15230BCCB292B982A2EB840BF0581CF5"),
+			G: fromHex("F7E1A085D69B3DDECBBCAB5C36B857B97994AFBBFA3AEA82F9574C0B3D0782675159578EBAD4594FE67107108180B449167123E84C281613B7CF09328CC8A6E13C167A8B547C8D28E0A3AE1E2BB3A675916EA37F0BFA213562F1FB627A01243BCCA4F1BEA8519089A883DFE15AE59F06928B665E807B552564014C3BFECF492A"),
+		},
+		},
+		X: fromHex("7D6E1A3DD4019FD809669D8AB8DA73807CEF7EC1"),
+	}
+	toBeSigned, err := NewSignedData(content)
+	if err != nil {
+		t.Fatalf("test case: cannot initialize signed data: %s", err)
+	}
+	if err := toBeSigned.SignWithoutAttr(signerCert, &priv, SignerInfoConfig{}); err != nil {
+		t.Fatalf("Cannot add signer: %s", err)
+	}
+	toBeSigned.Detach()
+	signed, err := toBeSigned.Finish()
+	if err != nil {
+		t.Fatalf("test case: cannot finish signing data: %s", err)
+	}
+
+	// write the signature to a temp file
+	tmpSignatureFile, err := ioutil.TempFile("", "TestDSASignAndVerifyWithOpenSSL_signature")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(tmpSignatureFile.Name(), pem.EncodeToMemory(&pem.Block{Type: "PKCS7", Bytes: signed}), 0755)
+
+	// call openssl to verify the signature on the content using the root
+	opensslCMD := exec.Command("openssl", "smime", "-verify", "-noverify",
+		"-in", tmpSignatureFile.Name(), "-inform", "PEM",
+		"-content", tmpContentFile.Name())
+	out, err := opensslCMD.CombinedOutput()
+	if err != nil {
+		t.Fatalf("test case: openssl command failed with %s: %s", err, out)
+	}
+	os.Remove(tmpSignatureFile.Name())  // clean up
+	os.Remove(tmpContentFile.Name())    // clean up
+	os.Remove(tmpSignerCertFile.Name()) // clean up
 }
 
 func TestSignWithoutAttributes(t *testing.T) {
@@ -173,7 +240,7 @@ func ExampleSignedData() {
 	}
 
 	// Add the signing cert and private key
-	if err := signedData.AddSigner(cert.Certificate, (*cert.PrivateKey).(crypto.Signer), SignerInfoConfig{}); err != nil {
+	if err := signedData.AddSigner(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{}); err != nil {
 		fmt.Printf("Cannot add signer: %s", err)
 	}
 
@@ -203,7 +270,7 @@ func TestSetContentType(t *testing.T) {
 	idctTSTInfo := asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 1, 4}
 	signedData.SetContentType(idctTSTInfo)
 
-	if err := signedData.AddSigner(cert.Certificate, (*cert.PrivateKey).(crypto.Signer), SignerInfoConfig{}); err != nil {
+	if err := signedData.AddSigner(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{}); err != nil {
 		t.Fatalf("Cannot add signer: %s", err)
 	}
 
@@ -230,7 +297,7 @@ func TestUnmarshalSignedAttribute(t *testing.T) {
 	}
 	oidTest := asn1.ObjectIdentifier{2, 3, 4, 5, 6, 7}
 	testValue := "TestValue"
-	if err := toBeSigned.AddSigner(cert.Certificate, (*cert.PrivateKey).(crypto.Signer), SignerInfoConfig{
+	if err := toBeSigned.AddSigner(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{
 		ExtraSignedAttributes: []Attribute{Attribute{Type: oidTest, Value: testValue}},
 	}); err != nil {
 		t.Fatalf("Cannot add signer: %s", err)
@@ -276,7 +343,7 @@ func TestSkipCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot initialize signed data: %s", err)
 	}
-	if err := toBeSigned.AddSigner(cert.Certificate, (*cert.PrivateKey).(crypto.Signer), SignerInfoConfig{
+	if err := toBeSigned.AddSigner(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{
 		SkipCertificates: true,
 	}); err != nil {
 		t.Fatalf("Cannot add signer: %s", err)

--- a/sign_test.go
+++ b/sign_test.go
@@ -240,7 +240,7 @@ func ExampleSignedData() {
 	}
 
 	// Add the signing cert and private key
-	if err := signedData.AddSigner(cert.Certificate, *cert.PrivateKey, SignerInfoConfig{}); err != nil {
+	if err := signedData.AddSigner(cert.Certificate, cert.PrivateKey, SignerInfoConfig{}); err != nil {
 		fmt.Printf("Cannot add signer: %s", err)
 	}
 

--- a/verify.go
+++ b/verify.go
@@ -317,6 +317,8 @@ func getSignatureAlgorithm(digestEncryption, digest pkix.AlgorithmIdentifier) (x
 			return -1, fmt.Errorf("pkcs7: unsupported digest %q for encryption algorithm %q",
 				digest.Algorithm.String(), digestEncryption.Algorithm.String())
 		}
+	case digestEncryption.Algorithm.Equal(OIDEncryptionAlgorithmEDDSA25519):
+		return x509.PureEd25519, nil
 	default:
 		return -1, fmt.Errorf("pkcs7: unsupported algorithm %q",
 			digestEncryption.Algorithm.String())


### PR DESCRIPTION
The motivation for this change is to support the `crypto.Signer` interface in `AddSigner/AddSignerChain`, which is used in the [`timestamp`](https://github.com/digitorus/timestamp/blob/master/timestamp.go#L619) library. Signing libraries like cloud KMS libraries do not expose private key material, so we need to support `crypto.Signer` instead of `crypto.PrivateKey`.

It seems like DSA was the only reason that `PrivateKey` was needed, since it didn't implement the `Signer` interface. I've changed the function to take in an `interface{}` to support both the `PrivateKey` and `crypto.Signer` types. I also added Ed25519 support. Ed25519 handles hashing internally, so for signing and verification, there is a special case to not precompute the digest of the message.

If you're happy to merge this, I will also make a change to pick up this new version in the timestamp library.