### PR TITLE
Add support for passing multiple certificate pools for verification

### DIFF
--- a/verify_test.go
+++ b/verify_test.go
@@ -263,12 +263,12 @@ func TestVerifyFirefoxAddon(t *testing.T) {
 	}
 
 	expiredTime := time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)
-	if err = p7.VerifyWithChainAtTime(certPool, expiredTime); err != nil {
+	if err = p7.VerifyWithChainAtTime(certPool, expiredTime); err == nil {
 		t.Errorf("Verify at expired time %s did not error", expiredTime)
 	}
 
 	notYetValidTime := time.Date(1999, time.July, 5, 0, 13, 0, 0, time.UTC)
-	if err = p7.VerifyWithChainAtTime(certPool, validTime); err != nil {
+	if err = p7.VerifyWithChainAtTime(certPool, notYetValidTime); err == nil {
 		t.Errorf("Verify at not yet valid time %s did not error", notYetValidTime)
 	}
 


### PR DESCRIPTION
@malancas and I have been working on timestamp verification. As part of that work, we needed to verify a timestamp that does not include the entire certificate chain in the pkcs7 structure. Our PKI has both intermediate and root CAs, so we needed to pass not only a trust root pool but also the intermediate pool to verify the certificate.

A function has been added that takes in `x509.VerifyOptions`, which allows us to pass a root and intermediate pool to the verifier. This also has the benefit of being able to pass in which extended key usages you want to verify, and the time you'd like to verify at.

No breaking changes have been made to the external API. You can still pass in only a root pool, and the verifier will populate intermediates from the `p7.Certificates` structure.

@malancas plans to follow up this PR with a refactor of the verification code to remove some of the duplication and add some more tests.