### PR TITLE
Cleanup tests and print statements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,9 @@ jobs:
         go-version: ${{ matrix.go }}
         stable: false
     - name: Test
+      env:
+        # set this environment variable to true so tests can be run with the
+        # sha1 algorithm. Without this set, tests fail because Go marks sha1
+        # as insecure
+        GODEBUG: x509sha1=1
       run: go vet . && go build . && go test -count=1 -covermode=count -coverprofile=coverage.out .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Test
       env:
         # set this environment variable to true so tests can be run with the
-        # sha1 algorithm. Without this set, tests fail because Go marks sha1
-        # as insecure
+        # sha1 algorithm. Without this set, tests fail because Go notes the
+        # SHA1 algorithm as insecure
         GODEBUG: x509sha1=1
       run: go vet . && go build . && go test -count=1 -covermode=count -coverprofile=coverage.out .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: vet staticcheck test
 
 test:
-	go test -covermode=count -coverprofile=coverage.out .
+	GODEBUG=x509sha1=1 go test -covermode=count -coverprofile=coverage.out .
 
 showcoverage: test
 	go tool cover -html=coverage.out

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -12,9 +12,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"math/big"
-	"os"
 	"time"
 )
 
@@ -283,7 +281,6 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 		issuerKey = priv
 	}
 
-	log.Println("creating cert", name, "issued by", issuerCert.Subject.CommonName, "with sigalg", sigAlg)
 	switch priv.(type) {
 	case *rsa.PrivateKey:
 		switch issuerKey := issuerKey.(type) {
@@ -341,7 +338,6 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 	if err != nil {
 		return nil, err
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 	return &certKeyPair{
 		Certificate: cert,
 		PrivateKey:  &priv,

--- a/sign_test.go
+++ b/sign_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/big"
 	"os"
 	"os/exec"
@@ -19,10 +18,8 @@ import (
 func TestSign(t *testing.T) {
 	content := []byte("Hello World")
 	sigalgs := []x509.SignatureAlgorithm{
-		x509.SHA1WithRSA,
 		x509.SHA256WithRSA,
 		x509.SHA512WithRSA,
-		x509.ECDSAWithSHA1,
 		x509.ECDSAWithSHA256,
 		x509.ECDSAWithSHA384,
 		x509.ECDSAWithSHA512,
@@ -48,7 +45,6 @@ func TestSign(t *testing.T) {
 					t.Fatalf("test %s/%s/%s: cannot generate signer cert: %s", sigalgroot, sigalginter, sigalgsigner, err)
 				}
 				for _, testDetach := range []bool{false, true} {
-					log.Printf("test %s/%s/%s detached %t\n", sigalgroot, sigalginter, sigalgsigner, testDetach)
 					toBeSigned, err := NewSignedData(content)
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot initialize signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
@@ -68,7 +64,6 @@ func TestSign(t *testing.T) {
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot finish signing data: %s", sigalgroot, sigalginter, sigalgsigner, err)
 					}
-					pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
 					p7, err := Parse(signed)
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot parse signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
@@ -161,10 +156,8 @@ func TestDSASignAndVerifyWithOpenSSL(t *testing.T) {
 func TestSignWithoutAttributes(t *testing.T) {
 	content := []byte("Hello World")
 	sigalgs := []x509.SignatureAlgorithm{
-		x509.SHA1WithRSA,
 		x509.SHA256WithRSA,
 		x509.SHA512WithRSA,
-		x509.ECDSAWithSHA1,
 		x509.ECDSAWithSHA256,
 		x509.ECDSAWithSHA384,
 		x509.ECDSAWithSHA512,
@@ -183,7 +176,6 @@ func TestSignWithoutAttributes(t *testing.T) {
 				t.Fatalf("test %s/%s: cannot generate signer cert: %s", sigalgroot, sigalgsigner, err)
 			}
 			for _, testDetach := range []bool{false, true} {
-				log.Printf("test %s/%s/%s detached %t\n", sigalgroot, sigalgroot, sigalgsigner, testDetach)
 				toBeSigned, err := NewSignedData(content)
 				if err != nil {
 					t.Fatalf("test %s/%s: cannot initialize signed data: %s", sigalgroot, sigalgsigner, err)
@@ -203,7 +195,6 @@ func TestSignWithoutAttributes(t *testing.T) {
 				if err != nil {
 					t.Fatalf("test %s/%s: cannot finish signing data: %s", sigalgroot, sigalgsigner, err)
 				}
-				pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
 				p7, err := Parse(signed)
 				if err != nil {
 					t.Fatalf("test %s/%s: cannot parse signed data: %s", sigalgroot, sigalgsigner, err)
@@ -249,11 +240,10 @@ func ExampleSignedData() {
 	signedData.Detach()
 
 	// Finish() to obtain the signature bytes
-	detachedSignature, err := signedData.Finish()
+	_, err = signedData.Finish()
 	if err != nil {
 		fmt.Printf("Cannot finish signing data: %s", err)
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
 }
 
 func TestSetContentType(t *testing.T) {
@@ -330,7 +320,6 @@ func TestDegenerateCertificate(t *testing.T) {
 		t.Fatal(err)
 	}
 	testOpenSSLParse(t, deg)
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: deg})
 }
 
 func TestSkipCertificates(t *testing.T) {

--- a/sign_test.go
+++ b/sign_test.go
@@ -18,8 +18,10 @@ import (
 func TestSign(t *testing.T) {
 	content := []byte("Hello World")
 	sigalgs := []x509.SignatureAlgorithm{
+		x509.SHA1WithRSA,
 		x509.SHA256WithRSA,
 		x509.SHA512WithRSA,
+		x509.ECDSAWithSHA1,
 		x509.ECDSAWithSHA256,
 		x509.ECDSAWithSHA384,
 		x509.ECDSAWithSHA512,
@@ -156,8 +158,10 @@ func TestDSASignAndVerifyWithOpenSSL(t *testing.T) {
 func TestSignWithoutAttributes(t *testing.T) {
 	content := []byte("Hello World")
 	sigalgs := []x509.SignatureAlgorithm{
+		x509.SHA1WithRSA,
 		x509.SHA256WithRSA,
 		x509.SHA512WithRSA,
+		x509.ECDSAWithSHA1,
 		x509.ECDSAWithSHA256,
 		x509.ECDSAWithSHA384,
 		x509.ECDSAWithSHA512,

--- a/verify_test.go
+++ b/verify_test.go
@@ -471,10 +471,10 @@ but that's not what ships are built for.
 	}
 	ioutil.WriteFile(tmpContentFile.Name(), content, 0755)
 	sigalgs := []x509.SignatureAlgorithm{
-		x509.SHA1WithRSA,
+		// x509.SHA1WithRSA,
 		x509.SHA256WithRSA,
 		x509.SHA512WithRSA,
-		x509.ECDSAWithSHA1,
+		// x509.ECDSAWithSHA1,
 		x509.ECDSAWithSHA256,
 		x509.ECDSAWithSHA384,
 		x509.ECDSAWithSHA512,

--- a/verify_test.go
+++ b/verify_test.go
@@ -471,10 +471,10 @@ but that's not what ships are built for.
 	}
 	ioutil.WriteFile(tmpContentFile.Name(), content, 0755)
 	sigalgs := []x509.SignatureAlgorithm{
-		// x509.SHA1WithRSA,
+		x509.SHA1WithRSA,
 		x509.SHA256WithRSA,
 		x509.SHA512WithRSA,
-		// x509.ECDSAWithSHA1,
+		x509.ECDSAWithSHA1,
 		x509.ECDSAWithSHA256,
 		x509.ECDSAWithSHA384,
 		x509.ECDSAWithSHA512,


### PR DESCRIPTION
This pull request cleans up print statements made throughout tests. When running the tests locally, it is difficult to follow test output due to all of the print statements. The print statements typically print a PEM encoded certificate.