### PR TITLE
Clean up testing print statements and export GetDigestOIDForSignatureAlgorithm to set DigestOID in SignedData

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,9 @@ jobs:
         go-version: ${{ matrix.go }}
         stable: false
     - name: Test
+      env:
+        # set this environment variable to true so tests can be run with the
+        # sha1 algorithm. Without this set, tests fail because Go notes the
+        # SHA1 algorithm as insecure
+        GODEBUG: x509sha1=1
       run: go vet . && go build . && go test -count=1 -covermode=count -coverprofile=coverage.out .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: vet staticcheck test
 
 test:
-	go test -covermode=count -coverprofile=coverage.out .
+	GODEBUG=x509sha1=1 go test -covermode=count -coverprofile=coverage.out .
 
 showcoverage: test
 	go tool cover -html=coverage.out

--- a/pkcs7.go
+++ b/pkcs7.go
@@ -101,9 +101,9 @@ func getHashForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
 	return crypto.Hash(0), ErrUnsupportedAlgorithm
 }
 
-// getDigestOIDForSignatureAlgorithm takes an x509.SignatureAlgorithm
+// GetDigestOIDForSignatureAlgorithm takes an x509.SignatureAlgorithm
 // and returns the corresponding OID digest algorithm
-func getDigestOIDForSignatureAlgorithm(digestAlg x509.SignatureAlgorithm) (asn1.ObjectIdentifier, error) {
+func GetDigestOIDForSignatureAlgorithm(digestAlg x509.SignatureAlgorithm) (asn1.ObjectIdentifier, error) {
 	switch digestAlg {
 	case x509.SHA1WithRSA, x509.ECDSAWithSHA1:
 		return OIDDigestAlgorithmSHA1, nil

--- a/pkcs7_test.go
+++ b/pkcs7_test.go
@@ -12,9 +12,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"math/big"
-	"os"
 	"time"
 )
 
@@ -283,7 +281,6 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 		issuerKey = priv
 	}
 
-	log.Println("creating cert", name, "issued by", issuerCert.Subject.CommonName, "with sigalg", sigAlg)
 	switch priv.(type) {
 	case *rsa.PrivateKey:
 		switch issuerKey := issuerKey.(type) {
@@ -341,7 +338,6 @@ func createTestCertificateByIssuer(name string, issuer *certKeyPair, sigAlg x509
 	if err != nil {
 		return nil, err
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 	return &certKeyPair{
 		Certificate: cert,
 		PrivateKey:  &priv,

--- a/sign_test.go
+++ b/sign_test.go
@@ -53,7 +53,7 @@ func TestSign(t *testing.T) {
 					}
 
 					// Set the digest to match the end entity cert
-					signerDigest, _ := getDigestOIDForSignatureAlgorithm(signerCert.Certificate.SignatureAlgorithm)
+					signerDigest, _ := GetDigestOIDForSignatureAlgorithm(signerCert.Certificate.SignatureAlgorithm)
 					toBeSigned.SetDigestAlgorithm(signerDigest)
 
 					if err := toBeSigned.AddSignerChain(signerCert.Certificate, *signerCert.PrivateKey, parents, SignerInfoConfig{}); err != nil {
@@ -186,7 +186,7 @@ func TestSignWithoutAttributes(t *testing.T) {
 				}
 
 				// Set the digest to match the end entity cert
-				signerDigest, _ := getDigestOIDForSignatureAlgorithm(signerCert.Certificate.SignatureAlgorithm)
+				signerDigest, _ := GetDigestOIDForSignatureAlgorithm(signerCert.Certificate.SignatureAlgorithm)
 				toBeSigned.SetDigestAlgorithm(signerDigest)
 
 				if err := toBeSigned.SignWithoutAttr(signerCert.Certificate, (*signerCert.PrivateKey).(crypto.Signer), SignerInfoConfig{}); err != nil {

--- a/sign_test.go
+++ b/sign_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/big"
 	"os"
 	"os/exec"
@@ -48,7 +47,6 @@ func TestSign(t *testing.T) {
 					t.Fatalf("test %s/%s/%s: cannot generate signer cert: %s", sigalgroot, sigalginter, sigalgsigner, err)
 				}
 				for _, testDetach := range []bool{false, true} {
-					log.Printf("test %s/%s/%s detached %t\n", sigalgroot, sigalginter, sigalgsigner, testDetach)
 					toBeSigned, err := NewSignedData(content)
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot initialize signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
@@ -68,7 +66,6 @@ func TestSign(t *testing.T) {
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot finish signing data: %s", sigalgroot, sigalginter, sigalgsigner, err)
 					}
-					pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
 					p7, err := Parse(signed)
 					if err != nil {
 						t.Fatalf("test %s/%s/%s: cannot parse signed data: %s", sigalgroot, sigalginter, sigalgsigner, err)
@@ -183,7 +180,6 @@ func TestSignWithoutAttributes(t *testing.T) {
 				t.Fatalf("test %s/%s: cannot generate signer cert: %s", sigalgroot, sigalgsigner, err)
 			}
 			for _, testDetach := range []bool{false, true} {
-				log.Printf("test %s/%s/%s detached %t\n", sigalgroot, sigalgroot, sigalgsigner, testDetach)
 				toBeSigned, err := NewSignedData(content)
 				if err != nil {
 					t.Fatalf("test %s/%s: cannot initialize signed data: %s", sigalgroot, sigalgsigner, err)
@@ -203,7 +199,6 @@ func TestSignWithoutAttributes(t *testing.T) {
 				if err != nil {
 					t.Fatalf("test %s/%s: cannot finish signing data: %s", sigalgroot, sigalgsigner, err)
 				}
-				pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: signed})
 				p7, err := Parse(signed)
 				if err != nil {
 					t.Fatalf("test %s/%s: cannot parse signed data: %s", sigalgroot, sigalgsigner, err)
@@ -249,11 +244,10 @@ func ExampleSignedData() {
 	signedData.Detach()
 
 	// Finish() to obtain the signature bytes
-	detachedSignature, err := signedData.Finish()
+	_, err = signedData.Finish()
 	if err != nil {
 		fmt.Printf("Cannot finish signing data: %s", err)
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: detachedSignature})
 }
 
 func TestSetContentType(t *testing.T) {
@@ -330,7 +324,6 @@ func TestDegenerateCertificate(t *testing.T) {
 		t.Fatal(err)
 	}
 	testOpenSSLParse(t, deg)
-	pem.Encode(os.Stdout, &pem.Block{Type: "PKCS7", Bytes: deg})
 }
 
 func TestSkipCertificates(t *testing.T) {


### PR DESCRIPTION
This pull request includes a few small changes, including cleaning up print statements in unit tests that were making it hard to follow test output.

It also exports the `GetDigestOIDForSignatureAlgorithm` function. We want to export this function because we noticed [`DigestOID` in `signedData` has been hardcoded to the SHA-256 OID](https://github.com/digitorus/timestamp/blob/master/timestamp.go#L599). After reading through the PKCS7 code, it looks like we can use `GetDigestOIDForSignatureAlgorithm` to set `DigestOID` using the signer's signature algorithm. The haydentherapper/timestamp fork has already been updated to use this function to set `DigestOID`. See https://github.com/haydentherapper/timestamp/pull/3

A pull request from https://github.com/haydentherapper/timestamp will be created once this pull request is approved and merged.

cc @haydentherapper